### PR TITLE
BUGFIX/MINOR(blackbox-exporter): Fix the use of tags `install` and `c…

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,6 +10,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 # TODO (VDO): replace by package
 - name: Download blackbox exporter binary to local folder

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
-  tags: install
+  tags:
+    - install
+    - configure
 
 - name: Set defaults file
   template:
@@ -14,6 +16,7 @@
     group: root
     mode: 0644
   register: _blackbox_defaults
+  tags: configure
 
 - name: Set blackbox configuration
   copy:
@@ -33,6 +36,7 @@
   when:
     - _blackbox_conf is changed or _blackbox_defaults is changed
     - not openio_blackbox_provision_only
+  tags: configure
 
 - name: Check that service is up
   uri:
@@ -44,6 +48,7 @@
     delay: 5
     until: _blackbox_check is success
     changed_when: false
+  tags: configure
   when:
     - not openio_blackbox_provision_only
 ...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,0 @@
-# roles/blackbox/vars/Debian.yml
-# Distribution-specific variables for Ubuntu, Debian, ...
----
-blackbox_packages:
-  - openio-blackbox
-syslog_user: syslog
-...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,7 +1,0 @@
-# roles/blackbox/vars/RedHat.yml
-# Distribution-specific variables for RHEL, CentOS, ...
----
-blackbox_packages:
-  - openio-blackbox
-syslog_user: openio
-...


### PR DESCRIPTION
…onfigure`

 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION