### PR TITLE
BUGFIX/MINOR(blackbox): Fix retry loop when restarting service

### DIFF
--- a/files/blackbox_exporter.yml
+++ b/files/blackbox_exporter.yml
@@ -29,7 +29,7 @@ modules:
     timeout: 5s
   icmpcheck:
     icmp:
-      preferred_ip_protocol: ipv4
+      preferred_ip_protocol: ip4
     prober: icmp
     timeout: 5s
   meta0:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
   systemd:
     daemon_reload: true
     name: blackbox_exporter
-    state: "restarted"
+    state: "{{ 'started' if openio_blackbox_provision_only else 'restarted' }}"
     enabled: true
   when:
     - _blackbox_conf is changed or _blackbox_defaults is changed
@@ -43,12 +43,12 @@
     url: "http://{{ openio_blackbox_bind_address }}:{{ openio_blackbox_bind_port }}"
     return_content: true
     status_code: 200
-    register: _blackbox_check
-    retries: 3
-    delay: 5
-    until: _blackbox_check is success
-    changed_when: false
-  tags: configure
+  register: _blackbox_check
+  retries: 3
+  delay: 5
+  until: _blackbox_check is success
+  changed_when: false
   when:
     - not openio_blackbox_provision_only
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

The retry loop checking that service is up wasn't properly indented so
it didn't work correctly. This fixes the indentation and adds a missing
configure tag.

This also sets the proper protocol (ip4) in the config file

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION